### PR TITLE
Rename package to packageJson

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,5 +1,5 @@
 const forge = require('node-forge');
-const package = require('../package.json');
+const packageJson = require('../package.json');
 
 var formats = module.exports.validFormats = {
   der: 0,
@@ -28,7 +28,7 @@ function txtFormat(pem) {
   const d = new Date();
   return `Subject\t${crt.subject.value.map(rdn => rdn.value[0].value[1].value).join('/')}
 Valid\t${crt.valid.value.map(date => date.value).join(' - ')}
-Saved\t${d.toLocaleDateString()} ${d.toTimeString().replace(/\s*\(.*\)\s*/, '')} by ${package.name}@${package.version}
+Saved\t${d.toLocaleDateString()} ${d.toTimeString().replace(/\s*\(.*\)\s*/, '')} by ${packageJson.name}@${packageJson.version}
 ${pem}`;
 }
 


### PR DESCRIPTION
"package" is a reserved word in JS. babel fails to transform this package because of it.