### PR TITLE
Update vulnerable undici package version to a secure one

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "node-forge": "^1.3.1",
-        "undici": "^6.16.1"
+        "undici": "^6.19.2"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.1",
@@ -1865,9 +1865,10 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.16.1.tgz",
-      "integrity": "sha512-NeNiTT7ixpeiL1qOIU/xTVpHpVP0svmI6PwoCKaMGaI5AsHOaRdwqU/f7Fi9eyU4u03nd5U/BC8wmRMnS9nqoA==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.2.tgz",
+      "integrity": "sha512-JfjKqIauur3Q6biAtHJ564e3bWa8VvT+7cSiOJHFbX4Erv6CLGDpg8z+Fmg/1OI/47RA+GI2QZaF48SSaLvyBA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }
@@ -3347,9 +3348,9 @@
       "dev": true
     },
     "undici": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.16.1.tgz",
-      "integrity": "sha512-NeNiTT7ixpeiL1qOIU/xTVpHpVP0svmI6PwoCKaMGaI5AsHOaRdwqU/f7Fi9eyU4u03nd5U/BC8wmRMnS9nqoA=="
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.2.tgz",
+      "integrity": "sha512-JfjKqIauur3Q6biAtHJ564e3bWa8VvT+7cSiOJHFbX4Erv6CLGDpg8z+Fmg/1OI/47RA+GI2QZaF48SSaLvyBA=="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "node-forge": "^1.3.1",
-    "undici": "^6.16.1"
+    "undici": "^6.19.2"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.1",


### PR DESCRIPTION
MR for the following reason:

![CleanShot 2024-06-26 at 16 20 13@2x](https://github.com/jfromaniello/mac-ca/assets/6826944/a300a316-3928-4fc4-bb67-213ed27ce649)


Tests are fine 👍🏻